### PR TITLE
Add Net::Stomp connection check

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Changes for Plack::App::ServiceStatus
 
+0.901   2016-06-18T17:46:43
+    - better / more docs
+
+
 0.900   2016-06-13T15:02:50
     - first release
 

--- a/lib/Plack/App/ServiceStatus.pm
+++ b/lib/Plack/App/ServiceStatus.pm
@@ -3,7 +3,7 @@ use 5.018;
 use strict;
 use warnings;
 
-our $VERSION = '0.900';
+our $VERSION = '0.901';
 
 # ABSTRACT: Check and report status of various services needed by your app
 

--- a/lib/Plack/App/ServiceStatus.pm
+++ b/lib/Plack/App/ServiceStatus.pm
@@ -24,12 +24,12 @@ sub new {
     my @checks;
     while ( my ( $key, $value ) = each %args ) {
         my $module;
-        if ($key =~ /^\+/) {
+        if ( $key =~ /^\+/ ) {
             $module = $key;
-            $module=~s/^\+//;
+            $module =~ s/^\+//;
         }
         else {
-            $module = 'Plack::App::ServiceStatus::'.$key;
+            $module = 'Plack::App::ServiceStatus::' . $key;
         }
         try {
             use_module($module);
@@ -42,7 +42,8 @@ sub new {
             );
         }
         catch {
-            $log->errorf("%s: cannot init %s: %s",__PACKAGE__, $module, $_);
+            $log->errorf( "%s: cannot init %s: %s", __PACKAGE__, $module,
+                $_ );
         };
     }
 
@@ -72,7 +73,7 @@ sub to_app {
 
         foreach my $check ( @{ $self->checks } ) {
             my ( $status, $message ) = try {
-                return $check->{class}->check($check->{args});
+                return $check->{class}->check( $check->{args} );
             }
             catch {
                 return 'nok', "$_";
@@ -105,7 +106,7 @@ __END__
 
   my $status_app = Plack::App::ServiceStatus->new(
       app           => 'your app',
-      DBIC          => $schema,
+      DBIC          => [ $schema, 'select 1' ],
       Elasticsearch => $es, # instance of Search::Elasticsearch
   );
 
@@ -120,7 +121,9 @@ __END__
       mount '/_status' => 'Plack::App::ServiceStatus' => (
           app                     => literal(__PACKAGE__),
           Redis                   => 'redis',
-          '+MyApp::ServiceStatus' => literal("foo"),
+          '+MyApp::ServiceStatus' => {
+                foo => literal("foo")
+          },
       );
       route '/some/endpoint' => 'some_controller.some_action';
       # ...
@@ -128,7 +131,7 @@ __END__
 
 
   # checking the status
-  curl http://localhost:3000/_status  | json_pp
+  curl http://localhost:3000/_status | json_pp
   {
      "app" : "Your app",
      "started_at" : 1465823638,

--- a/lib/Plack/App/ServiceStatus.pm
+++ b/lib/Plack/App/ServiceStatus.pm
@@ -174,6 +174,8 @@ The following checks are currently available:
 
 =item * L<Plack::App::ServiceStatus::Elasticsearch>
 
+=item * L<Plack::App::ServiceStatus::NetStomp>
+
 =back
 
 Each check consists of a C<name> and a C<status>. The status can be

--- a/lib/Plack/App/ServiceStatus.pm
+++ b/lib/Plack/App/ServiceStatus.pm
@@ -156,7 +156,7 @@ __END__
 
 C<Plack::App::ServiceStatus> implements a small
 L<Plack|https://metacpan.org/pod/Plack> application that you can use
-to get some status info on your application and the services needed by
+to get some status info about your application and the services needed by
 it.
 
 You can then use some monitoring software to periodically check if
@@ -180,8 +180,16 @@ Each check consists of a C<name> and a C<status>. The status can be
 C<ok> or C<nok>. A check might also contain a C<message>, which should
 be some description of the error or problem if the status is C<nok>.
 
+Each check has to implement a method named C<check> which will be
+called with name of the class and the arguments you specified when
+setting up C<Plack::App::ServiceStatus>. C<check> has to return either
+the string C<ok>, or the string C<nok> and a string containing an
+explanation.
+
 You can add your own checks by specifying a name starting with a C<+>
-sign, for example C<+My::App::SomeStatusCheck>.
+sign, for example C<+My::App::SomeStatusCheck>. Or send me a pull
+request to include your check in this distribution, or just release it
+yourself!
 
 =head2 Weirdness
 
@@ -195,8 +203,6 @@ that here an embedded app is the better fit.
 =head1 TODO
 
 =over
-
-=item * proper documentation
 
 =item * tests
 

--- a/lib/Plack/App/ServiceStatus/DBIC.pm
+++ b/lib/Plack/App/ServiceStatus/DBIC.pm
@@ -22,3 +22,32 @@ sub check {
 
 1;
 
+__END__
+
+=head1 SYNOPSIS
+
+  my $schema     = YourApp::Schema->connect( ... );
+  my $status_app = Plack::App::ServiceStatus->new(
+      app  => 'your app',
+      DBIC => $schema,
+  );
+
+=head1 CHECK
+
+Gets C<dbh> from the schema object and executes a query, per default
+C<select 1;>. This query has to return C<1> to indicate that
+everything is ok.
+
+You can pass another query when loading C<Plack::App::ServiceStatus>:
+
+  my $status_app = Plack::App::ServiceStatus->new(
+      app           => 'your app',
+      DBIC          => [ $schema, '
+        SELECT CASE
+            WHEN count(*) > 0 THEN 1
+            ELSE 0
+        END
+        FROM some_table'
+      ],
+  );
+

--- a/lib/Plack/App/ServiceStatus/Elasticsearch.pm
+++ b/lib/Plack/App/ServiceStatus/Elasticsearch.pm
@@ -16,3 +16,18 @@ sub check {
 }
 
 1;
+
+__END__
+
+=head1 SYNOPSIS
+
+  my $es         = Search::Elasticsearch->new;
+  my $status_app = Plack::App::ServiceStatus->new(
+      app           => 'your app',
+      Elasticsearch => $es,
+  );
+
+=head1 CHECK
+
+Calls C<ping> on the C<$elasticsearch> object.
+

--- a/lib/Plack/App/ServiceStatus/NetStomp.pm
+++ b/lib/Plack/App/ServiceStatus/NetStomp.pm
@@ -1,0 +1,72 @@
+package Plack::App::ServiceStatus::NetStomp;
+use 5.018;
+use strict;
+use warnings;
+use Module::Runtime qw(require_module);
+use Try::Tiny;
+
+our $VERSION = '0.900';
+
+# ABSTRACT: Check Net::Stomp connection
+
+sub check {
+    my ( $class, $stomp ) = @_;
+
+    if ( ref $stomp eq 'CODE' ) {
+        $stomp = $stomp->();
+    }
+
+    require_module 'Net::Stomp::Frame';
+    my $reconnect_attempts = $stomp->reconnect_attempts();
+    return try {
+        $stomp->reconnect_attempts(1);
+        my $transaction_id = $stomp->_get_next_transaction;
+        my $begin_frame    = Net::Stomp::Frame->new(
+            {
+                command => 'BEGIN',
+                headers => { transaction => $transaction_id }
+            }
+        );
+        $stomp->send_frame($begin_frame);
+        my $abort_frame = Net::Stomp::Frame->new(
+            {
+                command => 'ABORT',
+                headers => { transaction => $transaction_id }
+            }
+        );
+        $stomp->send_frame($abort_frame);
+        return 'ok';
+    }
+    catch {
+        return 'nok', 'Not connected: ' . $_;
+    }
+    finally {
+        $stomp->reconnect_attempts($reconnect_attempts);
+    }
+}
+
+1;
+
+__END__
+
+=head1 SYNOPSIS
+
+  my $stomp = Net::Stomp->new(
+      { hostname => 'localhost', port => '61613' }
+  );
+  $stomp->connect( { login => 'hello', passcode => 'there' } );
+  my $status_app = Plack::App::ServiceStatus->new(
+      app      => 'your app',
+      NetStomp => $stomp,
+  );
+
+=head1 CHECK
+
+Temporarily reduces the C<reconnect_attempts> to 1, and then starts a new STOMP
+transaction which is immediately aborted again. If this is successful, the check
+returns C<ok>, otherwise C<nok> and the exception.
+
+=head1 PARAMETERS
+
+Takes either a L<Net::Stomp> instance (where C<connect()> was already called on)
+or a code reference which returns such a L<Net::Stomp> instance when called.

--- a/lib/Plack/App/ServiceStatus/Redis.pm
+++ b/lib/Plack/App/ServiceStatus/Redis.pm
@@ -16,3 +16,18 @@ sub check {
 }
 
 1;
+
+__END__
+
+=head1 SYNOPSIS
+
+  my $redis      = Redis->new;
+  my $status_app = Plack::App::ServiceStatus->new(
+      app   => 'your app',
+      Redis => $redis,
+  );
+
+=head1 CHECK
+
+Calls C<ping> on the C<$redis> object.
+

--- a/t/netstomp.t
+++ b/t/netstomp.t
@@ -1,0 +1,48 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More;
+use Test::MockObject;
+use Test::MockModule;
+use Plack::App::ServiceStatus::NetStomp;
+
+Test::MockObject->fake_module('Net::Stomp::Frame');
+Test::MockObject->fake_new('Net::Stomp::Frame');
+
+my $stomp              = Test::MockObject->new();
+my $reconnect_attempts = 0;
+$stomp->mock(
+    reconnect_attempts => sub {
+        if ( scalar @_ == 2 ) {
+            $reconnect_attempts = $_[1];
+        }
+        return $reconnect_attempts;
+    }
+);
+$stomp->mock( send_frame => sub { } );
+my $txns = 0;
+$stomp->mock( _get_next_transaction => sub { $txns++ } );
+
+subtest 'check success case' => sub {
+    my @result = Plack::App::ServiceStatus::NetStomp->check($stomp);
+    is( scalar @result,      1,    'result length ok' );
+    is( $result[0],          'ok', 'status ok' );
+    is( $reconnect_attempts, 0,    'reconnect attempts reset' );
+
+    @result = Plack::App::ServiceStatus::NetStomp->check( sub { $stomp } );
+    is( $result[0], 'ok', 'status ok' );
+};
+
+subtest 'check failure case' => sub {
+    $stomp->mock( send_frame => sub { die 'Connect failed' } );
+    my @result = Plack::App::ServiceStatus::NetStomp->check($stomp);
+    is( scalar @result, 2,     'result length ok' );
+    is( $result[0],     'nok', 'status not ok' );
+    like( $result[1], qr{Not connected: Connect failed}, 'message correct' );
+    is( $reconnect_attempts, 0, 'reconnect attempts reset' );
+
+    @result = Plack::App::ServiceStatus::NetStomp->check( sub { $stomp } );
+    is( $result[0], 'nok', 'status not ok' );
+};
+
+done_testing;


### PR DESCRIPTION
This adds a check for `Net::Stomp` connections. Unfortunately, `STOMP` does not seem to support something like a ping, so the check starts and aborts a transaction and assumes everything is fine if that succeeds.

Btw., your published `master` branch is currently three commits behind the tag of the latest release of the dist. However, Github (understandably) does not seem to allow pull requests against tags, so my pull request also contains these three commits, since I branched off the `0.901` tag...