### PR TITLE
Add Icinga/Nagios check script

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Changes for Plack::App::ServiceStatus
 
+0.901   2016-06-18T17:46:43
+    - better / more docs
+
+
 0.900   2016-06-13T15:02:50
     - first release
 

--- a/contrib/check_plack_app_servicestatus
+++ b/contrib/check_plack_app_servicestatus
@@ -1,0 +1,86 @@
+#!/usr/bin/env perl
+
+use 5.018;
+use strict;
+use warnings;
+
+use HTTP::Tiny;
+use Try::Tiny;
+use JSON::MaybeXS;
+use Monitoring::Plugin;
+
+my $mp = Monitoring::Plugin->new(
+    usage     => "Usage: %s -U|--url=<status url> [--perfdata]",
+    shortname => 'Service Status',
+    url       => 'https://github.com/domm/Plack-App-ServiceStatus/',
+    version   => '0.009',
+    license   => 'This is free software; you can redistribute it and/or modify
+it under the same terms as the Perl 5 programming language system itself.'
+);
+
+$mp->add_arg(
+    spec     => 'url|U=s',
+    help     => 'URL where Plack::App::ServiceStatus is mounted',
+    required => 1
+);
+
+$mp->add_arg(
+    spec => 'perfdata',
+    help => 'Output service uptime as performance data'
+);
+
+$mp->getopts();
+
+my $response = HTTP::Tiny->new(
+    max_redirect => 0,
+    timeout      => $mp->opts->timeout
+)->get( $mp->opts->url );
+unless ( $response->{success} ) {
+    if ( defined $response->{content} ) {
+        $response->{content} =~ s{\n}{}gxms;
+    }
+    $mp->plugin_exit(
+        return_code => CRITICAL,
+        message     => 'Failed to fetch status: '
+          . $response->{reason}
+          . ( $response->{content} ? ', "' . $response->{content} . '"' : '' )
+    );
+}
+
+my $content_type = $response->{headers}->{'content-type'} // '';
+unless ( $content_type eq 'application/json' ) {
+    $mp->plugin_exit(
+        return_code => CRITICAL,
+        message     => 'Expected JSON, got "' . $content_type . '"'
+    );
+}
+
+my $data = try {
+    return decode_json( $response->{content} );
+}
+catch {
+    $mp->plugin_exit(
+        return_code => CRITICAL,
+        message     => 'Failed to parse JSON: ' . $_
+    );
+};
+
+if ( $mp->opts->perfdata ) {
+    $mp->add_perfdata(
+        label => "uptime",
+        value => $data->{uptime} // 0,
+        uom   => "s"
+    );
+}
+
+my $ok = 1;
+my @message;
+for my $check ( @{ $data->{checks} // [] } ) {
+    $ok &&= ( $check->{status} // '' ) eq 'ok';
+    push @message, ( $check->{name} // '' ) . ': ' . ( $check->{status} // '' );
+}
+
+$mp->plugin_exit(
+    return_code => $ok ? OK : WARNING,
+    message => join( ', ', @message )
+);

--- a/lib/Plack/App/ServiceStatus.pm
+++ b/lib/Plack/App/ServiceStatus.pm
@@ -3,7 +3,7 @@ use 5.018;
 use strict;
 use warnings;
 
-our $VERSION = '0.900';
+our $VERSION = '0.901';
 
 # ABSTRACT: Check and report status of various services needed by your app
 

--- a/lib/Plack/App/ServiceStatus.pm
+++ b/lib/Plack/App/ServiceStatus.pm
@@ -24,12 +24,12 @@ sub new {
     my @checks;
     while ( my ( $key, $value ) = each %args ) {
         my $module;
-        if ($key =~ /^\+/) {
+        if ( $key =~ /^\+/ ) {
             $module = $key;
-            $module=~s/^\+//;
+            $module =~ s/^\+//;
         }
         else {
-            $module = 'Plack::App::ServiceStatus::'.$key;
+            $module = 'Plack::App::ServiceStatus::' . $key;
         }
         try {
             use_module($module);
@@ -42,7 +42,8 @@ sub new {
             );
         }
         catch {
-            $log->errorf("%s: cannot init %s: %s",__PACKAGE__, $module, $_);
+            $log->errorf( "%s: cannot init %s: %s", __PACKAGE__, $module,
+                $_ );
         };
     }
 
@@ -72,7 +73,7 @@ sub to_app {
 
         foreach my $check ( @{ $self->checks } ) {
             my ( $status, $message ) = try {
-                return $check->{class}->check($check->{args});
+                return $check->{class}->check( $check->{args} );
             }
             catch {
                 return 'nok', "$_";
@@ -105,7 +106,7 @@ __END__
 
   my $status_app = Plack::App::ServiceStatus->new(
       app           => 'your app',
-      DBIC          => $schema,
+      DBIC          => [ $schema, 'select 1' ],
       Elasticsearch => $es, # instance of Search::Elasticsearch
   );
 
@@ -120,7 +121,9 @@ __END__
       mount '/_status' => 'Plack::App::ServiceStatus' => (
           app                     => literal(__PACKAGE__),
           Redis                   => 'redis',
-          '+MyApp::ServiceStatus' => literal("foo"),
+          '+MyApp::ServiceStatus' => {
+                foo => literal("foo")
+          },
       );
       route '/some/endpoint' => 'some_controller.some_action';
       # ...
@@ -128,7 +131,7 @@ __END__
 
 
   # checking the status
-  curl http://localhost:3000/_status  | json_pp
+  curl http://localhost:3000/_status | json_pp
   {
      "app" : "Your app",
      "started_at" : 1465823638,

--- a/lib/Plack/App/ServiceStatus.pm
+++ b/lib/Plack/App/ServiceStatus.pm
@@ -156,7 +156,7 @@ __END__
 
 C<Plack::App::ServiceStatus> implements a small
 L<Plack|https://metacpan.org/pod/Plack> application that you can use
-to get some status info on your application and the services needed by
+to get some status info about your application and the services needed by
 it.
 
 You can then use some monitoring software to periodically check if
@@ -180,8 +180,16 @@ Each check consists of a C<name> and a C<status>. The status can be
 C<ok> or C<nok>. A check might also contain a C<message>, which should
 be some description of the error or problem if the status is C<nok>.
 
+Each check has to implement a method named C<check> which will be
+called with name of the class and the arguments you specified when
+setting up C<Plack::App::ServiceStatus>. C<check> has to return either
+the string C<ok>, or the string C<nok> and a string containing an
+explanation.
+
 You can add your own checks by specifying a name starting with a C<+>
-sign, for example C<+My::App::SomeStatusCheck>.
+sign, for example C<+My::App::SomeStatusCheck>. Or send me a pull
+request to include your check in this distribution, or just release it
+yourself!
 
 =head2 Weirdness
 
@@ -195,8 +203,6 @@ that here an embedded app is the better fit.
 =head1 TODO
 
 =over
-
-=item * proper documentation
 
 =item * tests
 

--- a/lib/Plack/App/ServiceStatus/DBIC.pm
+++ b/lib/Plack/App/ServiceStatus/DBIC.pm
@@ -22,3 +22,32 @@ sub check {
 
 1;
 
+__END__
+
+=head1 SYNOPSIS
+
+  my $schema     = YourApp::Schema->connect( ... );
+  my $status_app = Plack::App::ServiceStatus->new(
+      app  => 'your app',
+      DBIC => $schema,
+  );
+
+=head1 CHECK
+
+Gets C<dbh> from the schema object and executes a query, per default
+C<select 1;>. This query has to return C<1> to indicate that
+everything is ok.
+
+You can pass another query when loading C<Plack::App::ServiceStatus>:
+
+  my $status_app = Plack::App::ServiceStatus->new(
+      app           => 'your app',
+      DBIC          => [ $schema, '
+        SELECT CASE
+            WHEN count(*) > 0 THEN 1
+            ELSE 0
+        END
+        FROM some_table'
+      ],
+  );
+

--- a/lib/Plack/App/ServiceStatus/Elasticsearch.pm
+++ b/lib/Plack/App/ServiceStatus/Elasticsearch.pm
@@ -16,3 +16,18 @@ sub check {
 }
 
 1;
+
+__END__
+
+=head1 SYNOPSIS
+
+  my $es         = Search::Elasticsearch->new;
+  my $status_app = Plack::App::ServiceStatus->new(
+      app           => 'your app',
+      Elasticsearch => $es,
+  );
+
+=head1 CHECK
+
+Calls C<ping> on the C<$elasticsearch> object.
+

--- a/lib/Plack/App/ServiceStatus/Redis.pm
+++ b/lib/Plack/App/ServiceStatus/Redis.pm
@@ -16,3 +16,18 @@ sub check {
 }
 
 1;
+
+__END__
+
+=head1 SYNOPSIS
+
+  my $redis      = Redis->new;
+  my $status_app = Plack::App::ServiceStatus->new(
+      app   => 'your app',
+      Redis => $redis,
+  );
+
+=head1 CHECK
+
+Calls C<ping> on the C<$redis> object.
+


### PR DESCRIPTION
This adds a script built on `Monitoring::Plugin` which fetches the status from a `Plack::App::ServiceStatus`-based resource and produces output suitable for Icinga/Nagios.

(In case you wonder why this PR contains three commits from you, see my note at the end of #1.)