### PR TITLE
Tidied up repo meta.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -15,7 +15,6 @@ exclude_match = local
 [ExecDir]
 [ShareDir]
 [Repository]
-git_remote = github
 
 [MetaResources]
 


### PR DESCRIPTION
Hi @domm 

Please review the PR.
It proposed fix to the error "Skipping invalid git remote github" as below:

        [DZ] beginning to build Plack-App-ServiceStatus
        [DZ] guessing dist's main_module is lib/Plack/App/ServiceStatus.pm
        [VersionFromModule] dist version 0.903 (from lib/Plack/App/ServiceStatus.pm)
        [Repository] Skipping invalid git remote github
        [CheckChangeLog] [CheckChangeLog] OK with Changes
        [DZ] writing Plack-App-ServiceStatus in Plack-App-ServiceStatus-0.903
        [DZ] building archive with Archive::Tar::Wrapper
        [DZ] writing archive to Plack-App-ServiceStatus-0.903.tar.gz
        [DZ] built in Plack-App-ServiceStatus-0.903

According to the plugin "Dist::Zilla::Plugin::Repository":

        git_remote
        This is the name of the remote to use for the public repository (if you use Git). By default, 
        unsurprisingly, to origin.

Many Thanks.
Best Regards,
Mohammad S Anwar
